### PR TITLE
Test case and possible fix for issue 63 : java.lang.ClassCastException on XsdAttribute:198 - xsd parser version 1.2.9

### DIFF
--- a/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAttribute.java
+++ b/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAttribute.java
@@ -195,7 +195,7 @@ public class XsdAttribute extends XsdNamedElements {
     }
 
     public XsdSimpleType getXsdSimpleType(){
-        return simpleType instanceof ConcreteElement ? (XsdSimpleType) simpleType.getElement() : null;
+        return ( simpleType != null && simpleType.getElement() instanceof XsdSimpleType ) ? (XsdSimpleType) simpleType.getElement() : null;
     }
 
     public String getType() {

--- a/src/test/java/org/xmlet/xsdparser/Issue63Test.java
+++ b/src/test/java/org/xmlet/xsdparser/Issue63Test.java
@@ -1,0 +1,32 @@
+package org.xmlet.xsdparser;
+
+import org.junit.Test;
+import org.xmlet.xsdparser.core.XsdParser;
+import org.xmlet.xsdparser.xsdelements.XsdComplexType;
+import org.xmlet.xsdparser.xsdelements.XsdElement;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/*
+ * Sample code to test issue https://github.com/xmlet/XsdParser/issues/63
+ */
+public class Issue63Test {
+
+    @Test
+    public void testIssue63() {
+        XsdParser xsdParser = new XsdParser( "./src/test/resources/issue_63/a.xsd" );
+        List<XsdElement> elements = xsdParser.getResultXsdElements().collect(Collectors.toList());
+        for (XsdElement currentElement : elements) {
+            XsdComplexType complexType = currentElement.getXsdComplexType();
+            if ( complexType != null ) {
+                Logger.getAnonymousLogger().log(Level.INFO, "current type : "+complexType );
+                // exception raised here
+                complexType.getXsdAttributes().forEach( a -> a.getAllRestrictions() );
+            }
+        }
+    }
+
+}

--- a/src/test/resources/issue_63/a.xsd
+++ b/src/test/resources/issue_63/a.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Sample test xsd for issue : https://github.com/xmlet/XsdParser/issues/63
+java.lang.ClassCastException on XsdAttribute:198 - xsd parser version 1.2.9
+-->
+<xsd:schema xmlns='http://www.w3.org/2000/10/XMLSchema'
+	targetNamespace='https://github.com/xmlet/XsdParser/issues/63'
+	xmlns:doc='https://github.com/xmlet/XsdParser/issues/63' xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<xsd:element name='info'>
+		<xsd:annotation>
+			<xsd:documentation>Some documentation text</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed='true'>
+			<xsd:attribute name='name' type='xsd:string' use='required'>
+				<xsd:annotation>
+					<xsd:documentation>More documentation text</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+</xsd:schema>


### PR DESCRIPTION
This fix does not address the behaviour change in patch 1.2.9, it just try to check type before casting to insure the operation is allowed.

I hope I don't miss some important change in patch 1.2.9 (but I quickly reviewd the changeset, the fix should be safe).

Thanks again for your work @lcduarte .
