### PR TITLE
Fix [1.2.12] XsdSimpleType : NullPointerException on XsdParserCore.getXsdTypeToJava(unionMemberRestriction.getBase()) #67

### DIFF
--- a/src/main/java/org/xmlet/xsdparser/xsdelements/XsdSimpleType.java
+++ b/src/main/java/org/xmlet/xsdparser/xsdelements/XsdSimpleType.java
@@ -171,7 +171,7 @@ public class XsdSimpleType extends XsdNamedElements {
                 XsdRestriction unionMemberRestriction = unionMember.getRestriction();
 
                 if (unionMemberRestriction != null){
-                    XsdRestriction existingRestriction = restrictions.getOrDefault(XsdParserCore.getXsdTypeToJava(unionMemberRestriction.getBase()), null);
+                    XsdRestriction existingRestriction = restrictions.getOrDefault( unionMemberRestriction.getBase() == null ? null : XsdParserCore.getXsdTypeToJava(unionMemberRestriction.getBase()), null);
 
                     if (existingRestriction != null){
                         if (existsRestrictionOverlap(existingRestriction, unionMemberRestriction)){
@@ -180,7 +180,7 @@ public class XsdSimpleType extends XsdNamedElements {
 
                         updateExistingRestriction(existingRestriction, unionMemberRestriction);
                     } else {
-                        restrictions.put(XsdParserCore.getXsdTypeToJava(unionMemberRestriction.getBase()), unionMemberRestriction);
+                        restrictions.put( unionMemberRestriction.getBase() == null ? null : XsdParserCore.getXsdTypeToJava(unionMemberRestriction.getBase()), unionMemberRestriction);
                     }
                 }
             });

--- a/src/test/java/org/xmlet/xsdparser/IssuesTest.java
+++ b/src/test/java/org/xmlet/xsdparser/IssuesTest.java
@@ -898,6 +898,23 @@ public class IssuesTest {
     }
 
     @Test
+    public void testIssue67() {
+        XsdParser xsdParser = new XsdParser( getFilePath("issue_67/a.xsd"));
+        List<XsdElement> elements = xsdParser.getResultXsdElements().collect(Collectors.toList());
+        for (XsdElement currentElement : elements) {
+            XsdSimpleType simpleType = currentElement.getXsdSimpleType();
+            if ( simpleType != null ) {
+                 /*
+                  * 1.2.12 code : restrictions.getOrDefault( XsdParserCore.getXsdTypeToJava(unionMemberRestriction.getBase(), null)
+                  * patch proposal : restrictions.getOrDefault( unionMemberRestriction.getBase() == null ? null : XsdParserCore.getXsdTypeToJava(unionMemberRestriction.getBase()), null)
+                  */
+                 // before the path here there is a NullPointerException on simpleType.getAllRestrictions()
+                 Assert.assertEquals( 2, simpleType.getAllRestrictions().size() );
+            }
+        }
+    }
+
+    @Test
     public void testPersons() {
         XsdParser parser = new XsdParser(getFilePath("persons/Person.xsd"));
 

--- a/src/test/resources/issue_67/a.xsd
+++ b/src/test/resources/issue_67/a.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Sample test xsd for issue : https://github.com/xmlet/XsdParser/issues/67
+xsd parser version 1.2.12
+-->
+<xsd:schema xmlns='http://www.w3.org/2000/10/XMLSchema'
+	targetNamespace='https://github.com/xmlet/XsdParser/issues/67'
+	xmlns:doc='https://github.com/xmlet/XsdParser/issues/67' xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<xsd:element name='info' type="doc:formatType">
+	</xsd:element>
+
+	<xsd:simpleType name="formatType">
+		<xsd:annotation>
+			<xsd:documentation>Data format</xsd:documentation>
+		</xsd:annotation>
+		<xsd:union memberTypes="doc:formatDateType">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:minLength value="1"/>
+					<xsd:maxLength value="128"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:union>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="formatDateType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="yyyy-MM-dd"></xsd:enumeration>
+			<xsd:enumeration value="yyyy-MM-dd hh:mm:ss"></xsd:enumeration>
+			<xsd:enumeration value="yyyy-MM-dd'T'HH:mm:ss.SSSZ"></xsd:enumeration>
+			<xsd:enumeration value="iso"></xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>


### PR DESCRIPTION
It seems to be this regression described in issue : 

https://github.com/xmlet/XsdParser/issues/67

Thanks again for this library.

@lcduarte Hope this pull request can be of help.

Regards