### PR TITLE
PR82 fix lost annotation of a element where ref another element

### DIFF
--- a/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
+++ b/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
@@ -447,6 +447,7 @@ public abstract class XsdParserCore {
 
                 if (!unsolvedReference.isTypeRef()) {
                     XsdNamedElements substitutionElement = (XsdNamedElements) concreteElement.getElement().clone(oldElementAttributes, concreteElement.getElement().getParent());
+                    substitutionElement.setAnnotation(unsolvedReference.getElement().getAnnotation());
 
                     substitutionElementWrapper = (NamedConcreteElement) ReferenceBase.createFromXsd(substitutionElement);
                 } else {
@@ -646,6 +647,7 @@ public abstract class XsdParserCore {
 
                 if (!unsolvedReference.isTypeRef()) {
                     XsdNamedElements substitutionElement = (XsdNamedElements) concreteElement.getElement().clone(oldElementAttributes, concreteElement.getElement().getParent());
+                    substitutionElement.setAnnotation(unsolvedReference.getElement().getAnnotation());
 
                     substitutionElementWrapper = (NamedConcreteElement) ReferenceBase.createFromXsd(substitutionElement);
                 } else {

--- a/src/test/java/org/xmlet/xsdparser/IssuesTest.java
+++ b/src/test/java/org/xmlet/xsdparser/IssuesTest.java
@@ -1090,7 +1090,7 @@ public class IssuesTest {
 				aElement.getAnnotation().getDocumentations().iterator().next().getContent());
 
 		XsdComplexType ct_issue_81 = xsdSchema.getChildrenComplexTypes()
-				.filter(ct -> ct.getName().equals("ct_issue_81")).findFirst().get();
+				.filter(ct -> ct.getName().equals("ct_issue_82")).findFirst().get();
 		XsdElement xsdElement = ct_issue_81.getChildAsSequence().getChildrenElements().findFirst().get();
 		XsdDocumentation lostAnnotation = xsdElement.getAnnotation().getDocumentations().iterator().next();
 		Assert.assertEquals("aElement", xsdElement.getRawName());

--- a/src/test/java/org/xmlet/xsdparser/IssuesTest.java
+++ b/src/test/java/org/xmlet/xsdparser/IssuesTest.java
@@ -1069,6 +1069,33 @@ public class IssuesTest {
         Assert.assertEquals("1", choiceAny.getMaxOccurs());
         Assert.assertEquals("skip", choiceAny.getProcessContents());
     }
+    
+	@Test
+	public void testIssue82_other_ns() {
+		testIssue82("issue_82/element_other_ns_ref_annotation.xsd");
+	}
+
+	@Test
+	public void testIssue82_inner_ns() {
+		testIssue82("issue_82/element_inner_ns_ref_annotation.xsd");
+	}
+	
+	private void testIssue82(String filename) {
+		XsdParser xsdParser = new XsdParser(getFilePath(filename));
+		XsdSchema xsdSchema = xsdParser.getResultXsdSchemas().findFirst().get();
+
+		XsdElement aElement = xsdSchema.getChildrenElements().findFirst().get();
+		Assert.assertEquals("aElement", aElement.getRawName());
+		Assert.assertEquals("This Annotation is available",
+				aElement.getAnnotation().getDocumentations().iterator().next().getContent());
+
+		XsdComplexType ct_issue_81 = xsdSchema.getChildrenComplexTypes()
+				.filter(ct -> ct.getName().equals("ct_issue_81")).findFirst().get();
+		XsdElement xsdElement = ct_issue_81.getChildAsSequence().getChildrenElements().findFirst().get();
+		XsdDocumentation lostAnnotation = xsdElement.getAnnotation().getDocumentations().iterator().next();
+		Assert.assertEquals("aElement", xsdElement.getRawName());
+		Assert.assertEquals("This is the lost annotation", lostAnnotation.getContent());
+	}
 
     @Test
     public void testForwardGroupRef() {

--- a/src/test/resources/issue_82/element_inner_ns_ref_annotation.xsd
+++ b/src/test/resources/issue_82/element_inner_ns_ref_annotation.xsd
@@ -8,7 +8,7 @@
 		</xs:annotation>
 	</xs:element>
 
-	<xs:complexType name="ct_issue_81">
+	<xs:complexType name="ct_issue_82">
 		<xs:sequence>
 			<xs:element ref="aElement">
 				<xs:annotation>

--- a/src/test/resources/issue_82/element_inner_ns_ref_annotation.xsd
+++ b/src/test/resources/issue_82/element_inner_ns_ref_annotation.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="https://github.com/xmlet/XsdParser/issues/81"
+	elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://github.com/xmlet/XsdParser/issues/81">
+
+	<xs:element name="aElement">
+		<xs:annotation>
+			<xs:documentation>This Annotation is available</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+
+	<xs:complexType name="ct_issue_81">
+		<xs:sequence>
+			<xs:element ref="aElement">
+				<xs:annotation>
+					<xs:documentation>This is the lost annotation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	
+</xs:schema>

--- a/src/test/resources/issue_82/element_other_ns_ref_annotation.xsd
+++ b/src/test/resources/issue_82/element_other_ns_ref_annotation.xsd
@@ -8,7 +8,7 @@
 		</annotation>
 	</element>
 
-	<complexType name="ct_issue_81">
+	<complexType name="ct_issue_82">
 		<sequence>
 			<element ref="tns:aElement">
 				<annotation>

--- a/src/test/resources/issue_82/element_other_ns_ref_annotation.xsd
+++ b/src/test/resources/issue_82/element_other_ns_ref_annotation.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="https://github.com/xmlet/XsdParser/issues/81"
+	elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://github.com/xmlet/XsdParser/issues/81">
+
+	<element name="aElement">
+		<annotation>
+			<documentation>This Annotation is available</documentation>
+		</annotation>
+	</element>
+
+	<complexType name="ct_issue_81">
+		<sequence>
+			<element ref="tns:aElement">
+				<annotation>
+					<documentation>This is the lost annotation</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+</schema>


### PR DESCRIPTION
Hello,

If an element is used that is defined elsewhere with the `ref` attribute, the element's annotation is ignored. See Unit Test and XSD.

Please review and provide feedback. It would be great if this PR could be merged and released.