### PR TITLE
wrong element is used if a ref="elementName" is not unique

### DIFF
--- a/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
+++ b/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
@@ -489,7 +489,7 @@ public abstract class XsdParserCore {
                             .distinct()
                             .collect(Collectors.toList()));
 
-                    List<ReferenceBase> includedElements = new ArrayList<>(parseElements.get(fileName));
+                    List<ReferenceBase> includedElements = new ArrayList<>();
 
                     includedFiles.stream().filter(Objects::nonNull).forEach(includedFile -> {
                         String includedFilename = includedFile.substring(includedFile.lastIndexOf("/") + 1);

--- a/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
+++ b/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
@@ -574,6 +574,9 @@ public abstract class XsdParserCore {
         }
     }
     private Optional<String> toRealFileName(String currentFileStr, String fileNameStr) {
+		if (fileNameStr.startsWith("http")) {
+			return Optional.of(fileNameStr);
+		}
         try {
             File fileBeingParsed = new File(currentFileStr);
             File fileBeingParsedFolder = new File(fileBeingParsed.getParent());

--- a/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
+++ b/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
@@ -618,13 +618,12 @@ public abstract class XsdParserCore {
         boolean replaced = false;
 
         if (concreteElements != null) {
-            Map<String, String> oldElementAttributes = new HashMap<>(unsolvedReference.getElement().getAttributesMap());
-
             for (NamedConcreteElement concreteElement : concreteElements) {
                 NamedConcreteElement substitutionElementWrapper;
 
                 if (!unsolvedReference.isTypeRef()) {
-                    XsdNamedElements substitutionElement = (XsdNamedElements) concreteElement.getElement().clone(oldElementAttributes, concreteElement.getElement().getParent());
+                    Map<String, String> attributesMap = unsolvedReference.getElement().getAttributesMap();
+					XsdNamedElements substitutionElement = (XsdNamedElements) concreteElement.getElement().clone(attributesMap, concreteElement.getElement().getParent());
                     substitutionElement.setAnnotation(unsolvedReference.getElement().getAnnotation());
 
                     substitutionElementWrapper = (NamedConcreteElement) ReferenceBase.createFromXsd(substitutionElement);

--- a/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAbstractElement.java
+++ b/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAbstractElement.java
@@ -295,7 +295,7 @@ public abstract class XsdAbstractElement {
     }
 
     public static boolean compareReference(NamedConcreteElement element, UnsolvedReference reference){
-        return compareReferenceName(element, reference.getRef()) && compareMinMaxOccurs(element, reference);
+        return compareReferenceName(element, reference.getRef()) ;
     }
 
     static boolean compareReferenceName(NamedConcreteElement element, String unsolvedRef){
@@ -304,16 +304,6 @@ public abstract class XsdAbstractElement {
         }
 
         return element.getName().equals(unsolvedRef);
-    }
-
-    private static boolean compareMinMaxOccurs(NamedConcreteElement element, UnsolvedReference reference) {
-        int elementMinOccurs = AttributeValidations.validateNonNegativeInteger("", MIN_OCCURS_TAG, element.getElement().getAttributesMap().getOrDefault(MIN_OCCURS_TAG, "1"));
-        String elementMaxOccurs = AttributeValidations.maxOccursValidation("", element.getElement().getAttributesMap().getOrDefault(MAX_OCCURS_TAG, "1"));
-
-        int referenceMinOccurs = AttributeValidations.validateNonNegativeInteger("", MIN_OCCURS_TAG, reference.getElement().getAttributesMap().getOrDefault(MIN_OCCURS_TAG, "1"));
-        String referenceMaxOccurs = AttributeValidations.maxOccursValidation("", reference.getElement().getAttributesMap().getOrDefault(MAX_OCCURS_TAG, "1"));
-
-        return Objects.equals(elementMinOccurs, referenceMinOccurs) && Objects.equals(elementMaxOccurs, referenceMaxOccurs);
     }
 
     /**

--- a/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAbstractElement.java
+++ b/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAbstractElement.java
@@ -155,7 +155,7 @@ public abstract class XsdAbstractElement {
      * @return A copy of the object from which is called upon.
      */
     public XsdAbstractElement clone(@NotNull Map<String, String> placeHolderAttributes, XsdAbstractElement parent){
-        XsdAbstractElement clone = clone(placeHolderAttributes);
+        XsdAbstractElement clone = clone(new HashMap<>(placeHolderAttributes));
         clone.setParent(parent);
 
         return clone;
@@ -284,7 +284,7 @@ public abstract class XsdAbstractElement {
         Optional<UnsolvedReference> optionalUnsolvedReference = elements.stream()
                 .filter(referenceBase -> referenceBase instanceof UnsolvedReference)
                 .map(referenceBase -> (UnsolvedReference) referenceBase)
-                .filter(unsolvedReference -> compareReference(element, unsolvedReference))
+                .filter(unsolvedReference -> compareReferenceNotNested(element, unsolvedReference))
                 .findFirst();
         if (!optionalUnsolvedReference.isPresent()) {
             return false;
@@ -292,6 +292,10 @@ public abstract class XsdAbstractElement {
         UnsolvedReference oldElement = optionalUnsolvedReference.get();
         elements.set(elements.indexOf(oldElement), ReferenceBase.clone(parser, element, oldElement.getParent()));
         return true;
+    }
+    
+    public static boolean compareReferenceNotNested(NamedConcreteElement element, UnsolvedReference reference){
+        return compareReferenceName(element, reference.getRef()) && isNotNested(element);
     }
 
     public static boolean compareReference(NamedConcreteElement element, UnsolvedReference reference){
@@ -305,6 +309,10 @@ public abstract class XsdAbstractElement {
 
         return element.getName().equals(unsolvedRef);
     }
+
+	private static boolean isNotNested(NamedConcreteElement e) {
+		return e.getElement().getParent() != null && e.getElement().getParent() instanceof XsdSchema;
+	}
 
     /**
      * @return The parent of the current {@link XsdAbstractElement} object.

--- a/src/test/java/org/xmlet/xsdparser/IssuesTest.java
+++ b/src/test/java/org/xmlet/xsdparser/IssuesTest.java
@@ -1096,6 +1096,28 @@ public class IssuesTest {
 		Assert.assertEquals("aElement", xsdElement.getRawName());
 		Assert.assertEquals("This is the lost annotation", lostAnnotation.getContent());
 	}
+	
+	@Test
+	public void testIssue83() {
+		XsdParser xsdParser = new XsdParser(getFilePath("issue_83/element_name_not_uq.xsd"));
+		XsdSchema xsdSchema = xsdParser.getResultXsdSchemas().findFirst().get();
+		
+		XsdElement rootElement = elementByName(xsdSchema.getChildrenElements(), "rootElemenet", XsdElement.class);
+		XsdComplexType ct = rootElement.getTypeAsComplexType();
+		Assert.assertEquals("ct_issue_83", ct.getRawName());
+		XsdSequence sequence = ct.getChildAsSequence();
+		XsdElement xsdElement = elementByName(sequence.getChildrenElements(), "aElement", XsdElement.class);
+		XsdElement original = ((XsdElement) xsdElement.getCloneOf());
+		Assert.assertEquals("The right element",getContent(original.getAnnotation()));	
+	}
+	
+	private static <E> E elementByName(Stream<? extends XsdNamedElements> elements, String name, Class<E> resultType) {
+		return resultType.cast(elements.filter(e -> e.getRawName().equals(name)).findAny().orElse(null));
+	}
+	
+	private static String getContent(XsdAnnotation annotation) {
+		return annotation.getDocumentations().iterator().next().getContent();
+	}
 
     @Test
     public void testForwardGroupRef() {

--- a/src/test/resources/issue_83/element_name_not_uq.xsd
+++ b/src/test/resources/issue_83/element_name_not_uq.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="https://github.com/xmlet/XsdParser/issues/83"
+	elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://github.com/xmlet/XsdParser/issues/83">
+
+	<xs:complexType name="ct_issue_83_with_element">
+		<xs:sequence>
+			<xs:element name="aElement">
+				<xs:annotation>
+					<xs:documentation>The wrong element</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="aElement">
+		<xs:annotation>
+			<xs:documentation>The right element</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+
+	<xs:complexType name="ct_issue_83">
+		<xs:sequence>
+			<xs:element ref="aElement" />
+		</xs:sequence>
+	</xs:complexType>
+	
+	<xs:element name="rootElemenet" type="ct_issue_83" />
+	
+</xs:schema>


### PR DESCRIPTION
Whilst investigating my issue, I came across [issue_80](https://github.com/xmlet/XsdParser/issues/80) / #79 and realised that the author @HennoVermeulen had likely made a mistake. He had written a workaround for the issue of duplicate objects. I fixed this problem in my first commit.

In my actual commit, I noticed that every call to `clone` modifies the `oldElementAttributes`. If there were still duplicate objects from the previous commit, this would cause side effects that I encountered whilst investigating this commit. Hence the commit before this. To prevent this problem in principle, I allways create a copy of the map in XsdAbstractElement

Finally, I noticed that all the tests run perfectly on Windows, but not on Linux. Specifically: testIssue26_Includes and testIssue25AutoAccessory. I ‘fixed’ this problem quite easily.

Perhaps it would be a good idea to use only URLs internally. I’ve already started doing this, but haven’t finished it yet. It makes handling ‘locations’ much easier.

Let me know if there's anything else I can do.