### PR TITLE
Refactor element lookup in replaceUnsolvedReference

### DIFF
--- a/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
+++ b/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
@@ -21,7 +21,9 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.lang.String.format;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
 
 public abstract class XsdParserCore {
 
@@ -617,36 +619,100 @@ public abstract class XsdParserCore {
         return replaceUnsolvedReference(concreteElements, unsolvedReference, fileName);
     }
 
-    private boolean replaceUnsolvedReference(List<NamedConcreteElement> concreteElements, UnsolvedReference unsolvedReference, String fileName) {
-        boolean replaced = false;
+    protected boolean replaceUnsolvedReference(List<NamedConcreteElement> concreteElements,
+			UnsolvedReference unsolvedReference, String fileName) {
+		if (concreteElements == null) {
+			storeUnsolvedItem(unsolvedReference);
+			return false;
+		}
+		if (concreteElements.size() == 1) {
+			boolean result = replaceUnsolvedElement(concreteElements.iterator().next(), unsolvedReference);
+			if (result) {
+				removeUnsolvedElements(unsolvedReference, fileName);
+			}
+			return result;
+		}
+		boolean replaced = replaceUnsolvedElement(find(concreteElements, unsolvedReference), unsolvedReference);
+		if (replaced) {
+			removeUnsolvedElements(unsolvedReference, fileName);
+		}
+		return replaced;
+	}
 
-        if (concreteElements != null) {
-            for (NamedConcreteElement concreteElement : concreteElements) {
-                NamedConcreteElement substitutionElementWrapper;
+	/**
+	 * finds the NamedConcreteElement for the UnsolvedReference. The logic is as
+	 * follows: if the element is a child of a Redefine, replace it with the
+	 * original element. Otherwise, if a Redefine is available, replace it with
+	 * that. In this case, the UnsolvedReference points to a Redefine. In the latter
+	 * case, all elements with a schema as parent are considered. If
+	 * UnsolvedReference is a TypeRef, the element must be a Simple or Complex Type.
+	 * If it is not a TypeRef, it must be an ElementRef.
+	 */
+	protected NamedConcreteElement find(List<NamedConcreteElement> elements, UnsolvedReference unsolvedReference) {
+		if (getRedefine(unsolvedReference) != null) {
+			String schemaLocation = getRedefine(unsolvedReference).getSchemaLocation();
+			return findSchema(elements, schemaLocation);
+		} else if (!findRedefines(elements).isEmpty()) {
+			for (NamedConcreteElement redefineElement : findRedefines(elements)) {
+				if (redefineElement.getElement().getXsdSchema().equals(unsolvedReference.getElement().getXsdSchema())) {
+					return redefineElement;
+				}
+			}
+			throw new RuntimeException(format("No redefine for Ref %s found", unsolvedReference.getRef()));
+		} else {
+			for (NamedConcreteElement e : elements) {
+				if (e.getElement().getParent() instanceof XsdSchema) {
+					if (unsolvedReference.isTypeRef()) {
+						if (e.getElement() instanceof XsdSimpleType || e.getElement() instanceof XsdComplexType) {
+							return e;
+						} // else {
+						continue;
+					} else {
+						return e;
+					}
+				}
+			}
+		}
+		return null;
+	}
 
-                if (!unsolvedReference.isTypeRef()) {
-                    Map<String, String> attributesMap = unsolvedReference.getElement().getAttributesMap();
-					XsdNamedElements substitutionElement = (XsdNamedElements) concreteElement.getElement().clone(attributesMap, concreteElement.getElement().getParent());
-                    substitutionElement.setAnnotation(unsolvedReference.getElement().getAnnotation());
+	protected static XsdRedefine getRedefine(UnsolvedReference unsolvedReference) {
+		XsdAbstractElement parent = unsolvedReference.getParent();
+		while (parent != null && !(parent instanceof XsdRedefine)) {
+			parent = parent.getParent();
+		}
+		return (XsdRedefine) parent;
+	}
 
-                    substitutionElementWrapper = (NamedConcreteElement) ReferenceBase.createFromXsd(substitutionElement);
-                } else {
-                    substitutionElementWrapper = concreteElement;
-                }
+	private void removeUnsolvedElements(UnsolvedReference unsolvedReference, String fileName) {
+		unsolvedElements.get(fileName).remove(unsolvedReference);
+		if (unsolvedElements.get(fileName).isEmpty()) {
+			unsolvedElements.remove(fileName);
+		}
+	}
 
-                replaced |= unsolvedReference.getParent().replaceUnsolvedElements(substitutionElementWrapper);
-            }
+	protected boolean replaceUnsolvedElement(NamedConcreteElement concreteElement, UnsolvedReference unsolvedReference) {
+		NamedConcreteElement substitutionElementWrapper;
+		if (!unsolvedReference.isTypeRef()) {
+			Map<String, String> attributesMap = unsolvedReference.getElement().getAttributesMap();
+			XsdNamedElements substitutionElement = (XsdNamedElements) concreteElement.getElement()
+					.clone(attributesMap, concreteElement.getElement().getParent());
+			substitutionElement.setAnnotation(unsolvedReference.getElement().getAnnotation());
 
-            unsolvedElements.get(fileName).remove(unsolvedReference);
+			substitutionElementWrapper = (NamedConcreteElement) ReferenceBase.createFromXsd(substitutionElement);
+		} else {
+			substitutionElementWrapper = concreteElement;
+		}
+		return unsolvedReference.getParent().replaceUnsolvedElements(substitutionElementWrapper);
+	}
+	
+	protected static NamedConcreteElement findSchema(List<NamedConcreteElement> elements, String name) {
+		return elements.stream().filter(e -> e.getElement().getXsdSchema().getFilePath().endsWith(name)).findAny().get();
+	}
 
-            if (unsolvedElements.get(fileName).isEmpty()){
-                unsolvedElements.remove(fileName);
-            }
-        } else {
-            storeUnsolvedItem(unsolvedReference);
-        }
-        return replaced;
-    }
+	protected static List<NamedConcreteElement> findRedefines(List<NamedConcreteElement> elements) {
+		return elements.stream().filter(e -> e.getElement().getParent() instanceof XsdRedefine).collect(toList());
+	}
 
     /**
      * Saves an occurrence of an element which couldn't be resolved in the {@link XsdParser#replaceUnsolvedReference}

--- a/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAbstractElement.java
+++ b/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAbstractElement.java
@@ -277,14 +277,14 @@ public abstract class XsdAbstractElement {
      */
     public boolean replaceUnsolvedElements(NamedConcreteElement element){
         List<ReferenceBase> elements = this.getElements();
-        if (elements == null){
+        if (elements.isEmpty()){
             return false;
         }
 
         Optional<UnsolvedReference> optionalUnsolvedReference = elements.stream()
                 .filter(referenceBase -> referenceBase instanceof UnsolvedReference)
                 .map(referenceBase -> (UnsolvedReference) referenceBase)
-                .filter(unsolvedReference -> compareReferenceNotNested(element, unsolvedReference))
+                .filter(unsolvedReference -> compareReference(element, unsolvedReference))
                 .findFirst();
         if (!optionalUnsolvedReference.isPresent()) {
             return false;
@@ -294,10 +294,6 @@ public abstract class XsdAbstractElement {
         return true;
     }
     
-    public static boolean compareReferenceNotNested(NamedConcreteElement element, UnsolvedReference reference){
-        return compareReferenceName(element, reference.getRef()) && isNotNested(element);
-    }
-
     public static boolean compareReference(NamedConcreteElement element, UnsolvedReference reference){
         return compareReferenceName(element, reference.getRef()) ;
     }
@@ -309,10 +305,6 @@ public abstract class XsdAbstractElement {
 
         return element.getName().equals(unsolvedRef);
     }
-
-	private static boolean isNotNested(NamedConcreteElement e) {
-		return e.getElement().getParent() != null && e.getElement().getParent() instanceof XsdSchema;
-	}
 
     /**
      * @return The parent of the current {@link XsdAbstractElement} object.

--- a/src/main/java/org/xmlet/xsdparser/xsdelements/XsdComplexType.java
+++ b/src/main/java/org/xmlet/xsdparser/xsdelements/XsdComplexType.java
@@ -12,7 +12,11 @@ import org.xmlet.xsdparser.xsdelements.visitors.XsdAbstractElementVisitor;
 import org.xmlet.xsdparser.xsdelements.visitors.XsdComplexTypeVisitor;
 
 import jakarta.validation.constraints.NotNull;
+
+import static java.util.Collections.emptyList;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -117,9 +121,8 @@ public class XsdComplexType extends XsdNamedElements {
     /**
      * @return The elements of his child as if they belong to the {@link XsdComplexType} instance.
      */
-    @Override
     public List<ReferenceBase> getElements() {
-        return childElement == null ? null : childElement.getElement().getElements();
+        return childElement == null ? emptyList() : childElement.getElement().getElements();
     }
 
     /**

--- a/src/test/java/org/xmlet/xsdparser/IssuesTest.java
+++ b/src/test/java/org/xmlet/xsdparser/IssuesTest.java
@@ -1102,7 +1102,7 @@ public class IssuesTest {
 		XsdParser xsdParser = new XsdParser(getFilePath("issue_83/element_name_not_uq.xsd"));
 		XsdSchema xsdSchema = xsdParser.getResultXsdSchemas().findFirst().get();
 		
-		XsdElement rootElement = elementByName(xsdSchema.getChildrenElements(), "rootElemenet", XsdElement.class);
+		XsdElement rootElement = elementByName(xsdSchema.getChildrenElements(), "rootElement", XsdElement.class);
 		XsdComplexType ct = rootElement.getTypeAsComplexType();
 		Assert.assertEquals("ct_issue_83", ct.getRawName());
 		XsdSequence sequence = ct.getChildAsSequence();

--- a/src/test/java/org/xmlet/xsdparser/RedefineTest.java
+++ b/src/test/java/org/xmlet/xsdparser/RedefineTest.java
@@ -1,5 +1,6 @@
 package org.xmlet.xsdparser;
 
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.*;
 
 import java.net.URL;
@@ -117,6 +118,11 @@ public class RedefineTest {
 
         XsdExtension personTypeExtension = personTypeComplexContent.getXsdExtension();
         assertNotNull(personTypeExtension);
+        
+        List<XsdElement> extensionElements = personTypeExtension.getBaseAsComplexType().getChildAsSequence().getChildrenElements().collect(toList());
+        assertEquals(2, extensionElements.size());
+        assertEquals(1, extensionElements.stream().filter(element -> element.getName().equals("name")).count());
+        assertEquals(1, extensionElements.stream().filter(element -> element.getName().equals("age")).count());
 
         XsdSequence personTypeSequence = personTypeExtension.getChildAsSequence();
         assertNotNull(personTypeSequence);

--- a/src/test/resources/issue_83/element_name_not_uq.xsd
+++ b/src/test/resources/issue_83/element_name_not_uq.xsd
@@ -24,6 +24,6 @@
 		</xs:sequence>
 	</xs:complexType>
 	
-	<xs:element name="rootElemenet" type="ct_issue_83" />
+	<xs:element name="rootElement" type="ct_issue_83" />
 	
 </xs:schema>


### PR DESCRIPTION
The logic is as follows: if the element is a child of a Redefine, replace it with the original element. Otherwise, if a Redefine is available, replace it with that. In this case, the UnsolvedReference points to a Redefine. In the latter case, all elements with a schema as parent are considered. If UnsolvedReference is a TypeRef, the element must be a Simple or Complex Type. If it is not a TypeRef, it must be an ElementRef.