### PR TITLE
wrong element is used if a ref="elementName" is not unique

### DIFF
--- a/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
+++ b/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
@@ -576,6 +576,9 @@ public abstract class XsdParserCore {
         }
     }
     private Optional<String> toRealFileName(String currentFileStr, String fileNameStr) {
+		if (fileNameStr.startsWith("http")) {
+			return Optional.of(fileNameStr);
+		}
         try {
             File fileBeingParsed = new File(currentFileStr);
             File fileBeingParsedFolder = new File(fileBeingParsed.getParent());

--- a/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
+++ b/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
@@ -489,7 +489,7 @@ public abstract class XsdParserCore {
                             .distinct()
                             .collect(Collectors.toList()));
 
-                    List<ReferenceBase> includedElements = new ArrayList<>(parseElements.get(fileName));
+                    List<ReferenceBase> includedElements = new ArrayList<>();
 
                     includedFiles.stream().filter(Objects::nonNull).forEach(includedFile -> {
                         String includedFilename = includedFile.substring(includedFile.lastIndexOf("/") + 1);

--- a/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
+++ b/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
@@ -21,7 +21,9 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.lang.String.format;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
 
 public abstract class XsdParserCore {
 
@@ -614,37 +616,100 @@ public abstract class XsdParserCore {
         return replaceUnsolvedReference(concreteElements, unsolvedReference, fileName);
     }
 
-    private boolean replaceUnsolvedReference(List<NamedConcreteElement> concreteElements, UnsolvedReference unsolvedReference, String fileName) {
-        boolean replaced = false;
+    protected boolean replaceUnsolvedReference(List<NamedConcreteElement> concreteElements,
+			UnsolvedReference unsolvedReference, String fileName) {
+		if (concreteElements == null) {
+			storeUnsolvedItem(unsolvedReference);
+			return false;
+		}
+		if (concreteElements.size() == 1) {
+			boolean result = replaceUnsolvedElement(concreteElements.iterator().next(), unsolvedReference);
+			if (result) {
+				removeUnsolvedElements(unsolvedReference, fileName);
+			}
+			return result;
+		}
+		boolean replaced = replaceUnsolvedElement(find(concreteElements, unsolvedReference), unsolvedReference);
+		if (replaced) {
+			removeUnsolvedElements(unsolvedReference, fileName);
+		}
+		return replaced;
+	}
 
-        if (concreteElements != null) {
-            Map<String, String> oldElementAttributes = new HashMap<>(unsolvedReference.getElement().getAttributesMap());
+	/**
+	 * finds the NamedConcreteElement for the UnsolvedReference. The logic is as
+	 * follows: if the element is a child of a Redefine, replace it with the
+	 * original element. Otherwise, if a Redefine is available, replace it with
+	 * that. In this case, the UnsolvedReference points to a Redefine. In the latter
+	 * case, all elements with a schema as parent are considered. If
+	 * UnsolvedReference is a TypeRef, the element must be a Simple or Complex Type.
+	 * If it is not a TypeRef, it must be an ElementRef.
+	 */
+	protected NamedConcreteElement find(List<NamedConcreteElement> elements, UnsolvedReference unsolvedReference) {
+		if (getRedefine(unsolvedReference) != null) {
+			String schemaLocation = getRedefine(unsolvedReference).getSchemaLocation();
+			return findSchema(elements, schemaLocation);
+		} else if (!findRedefines(elements).isEmpty()) {
+			for (NamedConcreteElement redefineElement : findRedefines(elements)) {
+				if (redefineElement.getElement().getXsdSchema().equals(unsolvedReference.getElement().getXsdSchema())) {
+					return redefineElement;
+				}
+			}
+			throw new RuntimeException(format("No redefine for Ref %s found", unsolvedReference.getRef()));
+		} else {
+			for (NamedConcreteElement e : elements) {
+				if (e.getElement().getParent() instanceof XsdSchema) {
+					if (unsolvedReference.isTypeRef()) {
+						if (e.getElement() instanceof XsdSimpleType || e.getElement() instanceof XsdComplexType) {
+							return e;
+						} // else {
+						continue;
+					} else {
+						return e;
+					}
+				}
+			}
+		}
+		return null;
+	}
 
-            for (NamedConcreteElement concreteElement : concreteElements) {
-                NamedConcreteElement substitutionElementWrapper;
+	protected static XsdRedefine getRedefine(UnsolvedReference unsolvedReference) {
+		XsdAbstractElement parent = unsolvedReference.getParent();
+		while (parent != null && !(parent instanceof XsdRedefine)) {
+			parent = parent.getParent();
+		}
+		return (XsdRedefine) parent;
+	}
 
-                if (!unsolvedReference.isTypeRef()) {
-                    XsdNamedElements substitutionElement = (XsdNamedElements) concreteElement.getElement().clone(oldElementAttributes, concreteElement.getElement().getParent());
-                    substitutionElement.setAnnotation(unsolvedReference.getElement().getAnnotation());
+	private void removeUnsolvedElements(UnsolvedReference unsolvedReference, String fileName) {
+		unsolvedElements.get(fileName).remove(unsolvedReference);
+		if (unsolvedElements.get(fileName).isEmpty()) {
+			unsolvedElements.remove(fileName);
+		}
+	}
 
-                    substitutionElementWrapper = (NamedConcreteElement) ReferenceBase.createFromXsd(substitutionElement);
-                } else {
-                    substitutionElementWrapper = concreteElement;
-                }
+	protected boolean replaceUnsolvedElement(NamedConcreteElement concreteElement, UnsolvedReference unsolvedReference) {
+		NamedConcreteElement substitutionElementWrapper;
+		if (!unsolvedReference.isTypeRef()) {
+			Map<String, String> attributesMap = unsolvedReference.getElement().getAttributesMap();
+			XsdNamedElements substitutionElement = (XsdNamedElements) concreteElement.getElement()
+					.clone(attributesMap, concreteElement.getElement().getParent());
+			substitutionElement.setAnnotation(unsolvedReference.getElement().getAnnotation());
 
-                replaced |= unsolvedReference.getParent().replaceUnsolvedElements(substitutionElementWrapper);
-            }
+			substitutionElementWrapper = (NamedConcreteElement) ReferenceBase.createFromXsd(substitutionElement);
+		} else {
+			substitutionElementWrapper = concreteElement;
+		}
+		return unsolvedReference.getParent().replaceUnsolvedElements(substitutionElementWrapper);
+	}
+	
+	protected static NamedConcreteElement findSchema(List<NamedConcreteElement> elements, String name) {
+		return elements.stream().filter(e -> e.getElement().getXsdSchema().getFilePath().endsWith(name)).findAny().get();
+	}
 
-            unsolvedElements.get(fileName).remove(unsolvedReference);
-
-            if (unsolvedElements.get(fileName).isEmpty()){
-                unsolvedElements.remove(fileName);
-            }
-        } else {
-            storeUnsolvedItem(unsolvedReference);
-        }
-        return replaced;
-    }
+	protected static List<NamedConcreteElement> findRedefines(List<NamedConcreteElement> elements) {
+		return elements.stream().filter(e -> e.getElement().getParent() instanceof XsdRedefine).collect(toList());
+	}
 
     /**
      * Saves an occurrence of an element which couldn't be resolved in the {@link XsdParser#replaceUnsolvedReference}

--- a/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAbstractElement.java
+++ b/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAbstractElement.java
@@ -295,7 +295,7 @@ public abstract class XsdAbstractElement {
     }
 
     public static boolean compareReference(NamedConcreteElement element, UnsolvedReference reference){
-        return compareReferenceName(element, reference.getRef()) && compareMinMaxOccurs(element, reference);
+        return compareReferenceName(element, reference.getRef()) ;
     }
 
     static boolean compareReferenceName(NamedConcreteElement element, String unsolvedRef){
@@ -304,16 +304,6 @@ public abstract class XsdAbstractElement {
         }
 
         return element.getName().equals(unsolvedRef);
-    }
-
-    private static boolean compareMinMaxOccurs(NamedConcreteElement element, UnsolvedReference reference) {
-        int elementMinOccurs = AttributeValidations.validateNonNegativeInteger("", MIN_OCCURS_TAG, element.getElement().getAttributesMap().getOrDefault(MIN_OCCURS_TAG, "1"));
-        String elementMaxOccurs = AttributeValidations.maxOccursValidation("", element.getElement().getAttributesMap().getOrDefault(MAX_OCCURS_TAG, "1"));
-
-        int referenceMinOccurs = AttributeValidations.validateNonNegativeInteger("", MIN_OCCURS_TAG, reference.getElement().getAttributesMap().getOrDefault(MIN_OCCURS_TAG, "1"));
-        String referenceMaxOccurs = AttributeValidations.maxOccursValidation("", reference.getElement().getAttributesMap().getOrDefault(MAX_OCCURS_TAG, "1"));
-
-        return Objects.equals(elementMinOccurs, referenceMinOccurs) && Objects.equals(elementMaxOccurs, referenceMaxOccurs);
     }
 
     /**

--- a/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAbstractElement.java
+++ b/src/main/java/org/xmlet/xsdparser/xsdelements/XsdAbstractElement.java
@@ -155,7 +155,7 @@ public abstract class XsdAbstractElement {
      * @return A copy of the object from which is called upon.
      */
     public XsdAbstractElement clone(@NotNull Map<String, String> placeHolderAttributes, XsdAbstractElement parent){
-        XsdAbstractElement clone = clone(placeHolderAttributes);
+        XsdAbstractElement clone = clone(new HashMap<>(placeHolderAttributes));
         clone.setParent(parent);
 
         return clone;
@@ -277,7 +277,7 @@ public abstract class XsdAbstractElement {
      */
     public boolean replaceUnsolvedElements(NamedConcreteElement element){
         List<ReferenceBase> elements = this.getElements();
-        if (elements == null){
+        if (elements.isEmpty()){
             return false;
         }
 
@@ -293,7 +293,7 @@ public abstract class XsdAbstractElement {
         elements.set(elements.indexOf(oldElement), ReferenceBase.clone(parser, element, oldElement.getParent()));
         return true;
     }
-
+    
     public static boolean compareReference(NamedConcreteElement element, UnsolvedReference reference){
         return compareReferenceName(element, reference.getRef()) ;
     }

--- a/src/main/java/org/xmlet/xsdparser/xsdelements/XsdComplexType.java
+++ b/src/main/java/org/xmlet/xsdparser/xsdelements/XsdComplexType.java
@@ -12,7 +12,11 @@ import org.xmlet.xsdparser.xsdelements.visitors.XsdAbstractElementVisitor;
 import org.xmlet.xsdparser.xsdelements.visitors.XsdComplexTypeVisitor;
 
 import jakarta.validation.constraints.NotNull;
+
+import static java.util.Collections.emptyList;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -117,9 +121,8 @@ public class XsdComplexType extends XsdNamedElements {
     /**
      * @return The elements of his child as if they belong to the {@link XsdComplexType} instance.
      */
-    @Override
     public List<ReferenceBase> getElements() {
-        return childElement == null ? null : childElement.getElement().getElements();
+        return childElement == null ? emptyList() : childElement.getElement().getElements();
     }
 
     /**

--- a/src/test/java/org/xmlet/xsdparser/IssuesTest.java
+++ b/src/test/java/org/xmlet/xsdparser/IssuesTest.java
@@ -1096,6 +1096,28 @@ public class IssuesTest {
 		Assert.assertEquals("aElement", xsdElement.getRawName());
 		Assert.assertEquals("This is the lost annotation", lostAnnotation.getContent());
 	}
+	
+	@Test
+	public void testIssue83() {
+		XsdParser xsdParser = new XsdParser(getFilePath("issue_83/element_name_not_uq.xsd"));
+		XsdSchema xsdSchema = xsdParser.getResultXsdSchemas().findFirst().get();
+		
+		XsdElement rootElement = elementByName(xsdSchema.getChildrenElements(), "rootElement", XsdElement.class);
+		XsdComplexType ct = rootElement.getTypeAsComplexType();
+		Assert.assertEquals("ct_issue_83", ct.getRawName());
+		XsdSequence sequence = ct.getChildAsSequence();
+		XsdElement xsdElement = elementByName(sequence.getChildrenElements(), "aElement", XsdElement.class);
+		XsdElement original = ((XsdElement) xsdElement.getCloneOf());
+		Assert.assertEquals("The right element",getContent(original.getAnnotation()));	
+	}
+	
+	private static <E> E elementByName(Stream<? extends XsdNamedElements> elements, String name, Class<E> resultType) {
+		return resultType.cast(elements.filter(e -> e.getRawName().equals(name)).findAny().orElse(null));
+	}
+	
+	private static String getContent(XsdAnnotation annotation) {
+		return annotation.getDocumentations().iterator().next().getContent();
+	}
 
     @Test
     public void testForwardGroupRef() {

--- a/src/test/java/org/xmlet/xsdparser/RedefineTest.java
+++ b/src/test/java/org/xmlet/xsdparser/RedefineTest.java
@@ -1,5 +1,6 @@
 package org.xmlet.xsdparser;
 
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.*;
 
 import java.net.URL;
@@ -117,6 +118,11 @@ public class RedefineTest {
 
         XsdExtension personTypeExtension = personTypeComplexContent.getXsdExtension();
         assertNotNull(personTypeExtension);
+        
+        List<XsdElement> extensionElements = personTypeExtension.getBaseAsComplexType().getChildAsSequence().getChildrenElements().collect(toList());
+        assertEquals(2, extensionElements.size());
+        assertEquals(1, extensionElements.stream().filter(element -> element.getName().equals("name")).count());
+        assertEquals(1, extensionElements.stream().filter(element -> element.getName().equals("age")).count());
 
         XsdSequence personTypeSequence = personTypeExtension.getChildAsSequence();
         assertNotNull(personTypeSequence);

--- a/src/test/resources/issue_83/element_name_not_uq.xsd
+++ b/src/test/resources/issue_83/element_name_not_uq.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="https://github.com/xmlet/XsdParser/issues/83"
+	elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://github.com/xmlet/XsdParser/issues/83">
+
+	<xs:complexType name="ct_issue_83_with_element">
+		<xs:sequence>
+			<xs:element name="aElement">
+				<xs:annotation>
+					<xs:documentation>The wrong element</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="aElement">
+		<xs:annotation>
+			<xs:documentation>The right element</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+
+	<xs:complexType name="ct_issue_83">
+		<xs:sequence>
+			<xs:element ref="aElement" />
+		</xs:sequence>
+	</xs:complexType>
+	
+	<xs:element name="rootElement" type="ct_issue_83" />
+	
+</xs:schema>


### PR DESCRIPTION
Whilst investigating my issue, I came across https://github.com/xmlet/XsdParser/issues/80 / https://github.com/xmlet/XsdParser/pull/79 and realised that the author @HennoVermeulen had likely made a mistake. He had written a workaround for the issue of duplicate objects. I fixed this problem in my first commit.

In my actual commit, I noticed that every call to clone modifies the oldElementAttributes. If there were still duplicate objects from the previous commit, this would cause side effects that I encountered whilst investigating this commit. Hence the commit before this. To prevent this problem in principle, I allways create a copy of the map in XsdAbstractElement

Finally, I noticed that all the tests run perfectly on Windows, but not on Linux. Specifically: testIssue26_Includes and testIssue25AutoAccessory. I ‘fixed’ this problem quite easily.

As noticed in #83 not in all situations all tests run, so I have to refactor the element lookup in replaceUnsolvedReference. The logic is as follows: if the element is a child of a Redefine, replace it with the original element. Otherwise, if a Redefine is available, replace it with that. In this case, the UnsolvedReference points to a Redefine. In the latter case, all elements with a schema as parent are considered. If UnsolvedReference is a TypeRef, the element must be a Simple or Complex Type. If it is not a TypeRef, it must be an ElementRef.

at the end, I open some usefull methods with protected, to give the ability to overwrite eventual bugs.