### PR TITLE
fix wrong parent of a element where ref another element

### DIFF
--- a/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
+++ b/src/main/java/org/xmlet/xsdparser/core/XsdParserCore.java
@@ -862,7 +862,7 @@ public abstract class XsdParserCore {
 		if (!unsolvedReference.isTypeRef()) {
 			Map<String, String> attributesMap = unsolvedReference.getElement().getAttributesMap();
 			XsdNamedElements substitutionElement = (XsdNamedElements) concreteElement.getElement()
-					.clone(attributesMap, concreteElement.getElement().getParent());
+					.clone(attributesMap, unsolvedReference.getElement().getParent());
 			substitutionElement.setAnnotation(unsolvedReference.getElement().getAnnotation());
 
 			substitutionElementWrapper = (NamedConcreteElement) ReferenceBase.createFromXsd(substitutionElement);

--- a/src/main/java/org/xmlet/xsdparser/xsdelements/elementswrapper/ReferenceBase.java
+++ b/src/main/java/org/xmlet/xsdparser/xsdelements/elementswrapper/ReferenceBase.java
@@ -77,9 +77,7 @@ public abstract class ReferenceBase {
             return unsolvedClonedElement;
         }
         else {
-            originalReference.getElement().setParentAvailable(false);
-
-            return  originalReference;
+			return originalReference;
 
 //            XsdAbstractElement cloneElement = originalElement.clone(originalElement.getAttributesMap());
 //            cloneElement.setParent(parent);

--- a/src/test/java/org/xmlet/xsdparser/IssuesTest.java
+++ b/src/test/java/org/xmlet/xsdparser/IssuesTest.java
@@ -1118,6 +1118,23 @@ public class IssuesTest {
 	private static String getContent(XsdAnnotation annotation) {
 		return annotation.getDocumentations().iterator().next().getContent();
 	}
+	
+	@Test
+	public void testIssue86() {
+		XsdParser xsdParser = new XsdParser(getFilePath("issue_86/element_ref_parent.xsd"));
+		XsdSchema xsdSchema = xsdParser.getResultXsdSchemas().findFirst().get();
+
+		XsdElement aElement = xsdSchema.getChildrenElements().findFirst().get();
+		Assert.assertEquals("aElement", aElement.getRawName());
+		Assert.assertEquals(xsdSchema, aElement.getParent());
+
+		XsdComplexType ct_issue_83 = xsdSchema.getChildrenComplexTypes()
+				.filter(ct -> ct.getName().equals("ct_issue_86")).findFirst().get();
+		XsdSequence sequence = ct_issue_83.getChildAsSequence();
+		XsdElement xsdElement = sequence.getChildrenElements().findFirst().get();
+		Assert.assertEquals("aElement", xsdElement.getRawName());
+		Assert.assertEquals(sequence, xsdElement.getParent());
+	}
 
     @Test
     public void testForwardGroupRef() {

--- a/src/test/resources/issue_86/element_ref_parent.xsd
+++ b/src/test/resources/issue_86/element_ref_parent.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+	targetNamespace="https://github.com/xmlet/XsdParser/issues/86"
+	elementFormDefault="qualified"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns="https://github.com/xmlet/XsdParser/issues/86">
+
+	<xs:element name="aElement" />
+
+	<xs:complexType name="ct_issue_86">
+		<xs:sequence>
+			<xs:element ref="aElement" />
+		</xs:sequence>
+	</xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
if a ref element is used inside a sequence, the parent have to be a sequence and not schema.

Could you have a look and see if it’s OK that I’ve deleted that line? `originalReference.getElement().setParentAvailable(false);`  I couldn’t find out why it was there.